### PR TITLE
Add real API clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,27 @@ This is an empty repository so I can try out vibe coding with OpenAI's codex. As
 - However, simply wrapping ChatGPT doesn't do the magic, as numerous other players tried and failed. In fact, it even directly competes with ChatGPT and doesn't do much better through "mere prompting"
 - What I want to build is to use our model - Tri - as the central orchestrator to allocate tasks to Gemini (default, multi-lingual reasoning, cheapest possible API), ChatGPT (generic reasoning, math, science, etc.), and Claude (Coding) according to their specialties.
 - Tri will take in user input, rewrite it in English (as it's superior in translation), and dispatch them to each API based on their specialities, take back the output from each model, score the best, translate and rewrite the best in Korean, and serve it back to the user.
+
+## Running the demo
+
+Install Python 3.10 or later. Then install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set the required API keys as environment variables:
+
+* `OPENAI_API_KEY` - key for OpenAI's ChatGPT API
+* `GEMINI_API_KEY` - key for Google's Gemini API
+* `ANTHROPIC_API_KEY` - key for Anthropic's Claude API
+
+Run the orchestrator:
+
+```bash
+python orchestrator.py
+```
+
+The program will repeatedly prompt for Korean input, send the translated
+request to each model, select the best response, translate it back to Korean
+and display the result.

--- a/llm_clients.py
+++ b/llm_clients.py
@@ -1,0 +1,83 @@
+"""Client implementations for each LLM used by the orchestrator."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+import openai
+import anthropic
+import google.generativeai as genai
+from googletrans import Translator
+
+
+class TriClient:
+    """Client for the Tri LLM including translation helpers."""
+
+    def __init__(self) -> None:
+        self.translator = Translator()
+
+    def translate_to_english(self, korean_text: str) -> str:
+        """Translate Korean text to English using Google Translate."""
+        result = self.translator.translate(korean_text, src="ko", dest="en")
+        return result.text
+
+    def translate_to_korean(self, english_text: str) -> str:
+        """Translate English text back to Korean using Google Translate."""
+        result = self.translator.translate(english_text, src="en", dest="ko")
+        return result.text
+
+    def score_responses(self, prompt: str, responses: Iterable[str]) -> str:
+        """Return the best response according to a simple heuristic."""
+        return max(responses, key=len)
+
+
+class GeminiClient:
+    """Client for Google's Gemini model."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gemini-pro") -> None:
+        api_key = api_key or os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            raise ValueError("GEMINI_API_KEY is not configured")
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(model)
+
+    def generate_response(self, prompt: str) -> str:
+        result = self.model.generate_content(prompt)
+        return result.text
+
+
+class ChatGPTClient:
+    """Client for OpenAI's ChatGPT models."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gpt-3.5-turbo") -> None:
+        self.model = model
+        openai.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if openai.api_key is None:
+            raise ValueError("OPENAI_API_KEY is not configured")
+
+    def generate_response(self, prompt: str) -> str:
+        completion = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return completion.choices[0].message.content.strip()
+
+
+class ClaudeClient:
+    """Client for Anthropic's Claude models."""
+
+    def __init__(self, api_key: str | None = None, model: str = "claude-3-opus-20240229") -> None:
+        api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError("ANTHROPIC_API_KEY is not configured")
+        self.client = anthropic.Anthropic(api_key=api_key)
+        self.model = model
+
+    def generate_response(self, prompt: str) -> str:
+        message = self.client.messages.create(
+            model=self.model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,45 @@
+"""Simple orchestrator that routes prompts through multiple LLMs."""
+
+from __future__ import annotations
+
+import os
+
+from llm_clients import TriClient, GeminiClient, ChatGPTClient, ClaudeClient
+
+
+class Orchestrator:
+    """Main orchestrator that delegates prompts to each LLM."""
+
+    def __init__(self) -> None:
+        self.tri = TriClient()
+        self.gemini = GeminiClient(api_key=os.environ.get("GEMINI_API_KEY"))
+        self.chatgpt = ChatGPTClient(api_key=os.environ.get("OPENAI_API_KEY"))
+        self.claude = ClaudeClient(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+    def chat(self, user_input: str) -> str:
+        """Process user input in Korean and return a Korean response."""
+        english_prompt = self.tri.translate_to_english(user_input)
+        responses = [
+            self.gemini.generate_response(english_prompt),
+            self.chatgpt.generate_response(english_prompt),
+            self.claude.generate_response(english_prompt),
+        ]
+        best_response = self.tri.score_responses(english_prompt, responses)
+        return self.tri.translate_to_korean(best_response)
+
+
+def main() -> None:
+    orchestrator = Orchestrator()
+    try:
+        while True:
+            user_input = input("User (Korean): ")
+            if not user_input:
+                break
+            reply = orchestrator.chat(user_input)
+            print(f"AI: {reply}")
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.0.0
+google-generativeai>=0.2.0
+anthropic>=0.3.0
+googletrans==4.0.0rc1


### PR DESCRIPTION
## Summary
- implement proper translation using googletrans
- wire up Gemini, ChatGPT and Claude API clients
- configure orchestrator to read API keys from the environment
- document setup in the README
- specify dependencies

## Testing
- `python -m py_compile llm_clients.py orchestrator.py`